### PR TITLE
Add 'suggested_channels' option & focus on first input on connect dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Relay.js supports simple server configuration via `config.json`. As time goes on
 
 * **max_connections** *integer* - The maximum number of connections that can be made from a single client.
 * **preset_server** *object* - An object specifying a preset server to connect to. This limits the user to a single connection to just this server. Parameters are **host**, **port**, and **password**.
+* **suggested_channels** *array* - An array of channels that populate the 'Channels' input on the connect dialog.
 
 To set these options, just make a `config.json` in the main directory of the app. Here's a quick example:
 
@@ -46,7 +47,11 @@ To set these options, just make a `config.json` in the main directory of the app
 {
 	"preset_server": {
 		"host": "irc.freenode.net"
-	}
+	},
+
+	"suggested_channels": [
+		"#relay.js"
+	]
 }
 ```
 

--- a/assets/scripts/views/connect.js
+++ b/assets/scripts/views/connect.js
@@ -20,7 +20,8 @@ irc.Views.Connect = Backbone.View.extend({
 	render: function(){
 
 		var html = this.template({
-			preset_server: irc.config.preset_server
+			preset_server: irc.config.preset_server,
+			suggested_channels: irc.config.suggested_channels.join( ',' )
 		});
 		var $connect = $.parseHTML( html );
 		this.$el.html( $connect );

--- a/assets/templates/connect.jst
+++ b/assets/templates/connect.jst
@@ -56,7 +56,7 @@
 				<div class="control-group">
 					<label for="connect_channels" class="control-label">Channels</label>
 					<div class="controls">
-						<input id="connect_channels" name="channels" placeholder="#relay.js" type="text" />
+						<input id="connect_channels" name="channels" value="{{suggested_channels}}" placeholder="#relay.js" type="text" />
 						<span class="help-inline">Optional</span>
 					</div>
 				</div>

--- a/lib/server.js
+++ b/lib/server.js
@@ -144,7 +144,8 @@ module.exports = function( params ){
 
 		res.expose({
 			preset_server: params.preset_server,
-			max_connections: params.max_connections
+			max_connections: params.max_connections,
+			suggested_channels: params.suggested_channels
 		}, 'irc.config' );
 		res.render( 'index.tpl', {} );
 

--- a/relay.js
+++ b/relay.js
@@ -34,7 +34,8 @@ getConfig( function( err, config ){
 	server({
 		home_dir: __dirname,
 		preset_server: config.preset_server,
-		max_connections: config.max_connections
+		max_connections: config.max_connections,
+		suggested_channels: config.suggested_channels || []
 	});
 
 });


### PR DESCRIPTION
I'm not sure about the name "suggested_channels" for the new option.  I considered "preset_channels" to be consistent with "preset_server", but unlike "preset_server" you can join other channels not listed in "suggested_channels".

Also, I'm not really experienced in web development (or pull requests!) so if anything is bad, let me know.  Ideally I want to conform to whatever style you had in mind for relay.js and learn a little about web stuff at the same time.
