### PR TITLE
use "serverName" when sending chans list to new connections

### DIFF
--- a/lib/irc_adapter.js
+++ b/lib/irc_adapter.js
@@ -277,7 +277,9 @@ module.exports = function( io ){
 
 			client.on( 'command', interpretCommand );
 
-			client.emit( 'chans', _(irc_client.chans).keys() );
+			client.emit( 'chans', _( irc_client.chans ).map( function( channel_data ){
+				return channel_data.serverName;
+			}) );
 			
 			client.on( 'disconnect', function(){
 


### PR DESCRIPTION
Emit channel names with proper capitalization when a new connection joins.
