### PR TITLE
Fix defaults.server.locked option to be working.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -79,7 +79,7 @@ module.exports = function( config ){
 
 		try {
 
-			var preset_server = ( config.defaults.locked )? config.defaults.server: {};
+			var preset_server = ( config.defaults.server.locked )? config.defaults.server: {};
 
 			irc_adapter = new Adapter({
 				server: preset_server.host || parameters.server,


### PR DESCRIPTION
Currently defaults.server.locked option is not working. I can see the server name when i set the option, but can't connect to server.

In lib/server.js, preset_server is filtered by whether config.defaults.locked is on or off. By documentation, (and by template codes like assets/templates/connect.hbs), the config option to lock default server is "config.defaults.server.locked", not "config.defaults.locked". This patch fixes it.
